### PR TITLE
Update cve-2019-19781_scanner.py

### DIFF
--- a/cve-2019-19781_scanner.py
+++ b/cve-2019-19781_scanner.py
@@ -5,13 +5,15 @@
 # Company: TrustedSec
 #
 import requests
-import urllib3
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning) # disable warnings
 import argparse
 
 def check_server(target, targetport):
-    req = requests.get("https://%s:%s/vpn/../vpns/cfg/smb.conf" % (target,targetport), verify=False)
-    if ("global") in req.content: # each smb.conf will contain a [global] variable
+    if targetport == '80':
+        req = requests.get("http://%s:%s/vpn/../vpns/cfg/smb.conf" % (target, targetport), verify=False)
+    else:
+        req = requests.get("https://%s:%s/vpn/../vpns/cfg/smb.conf" % (target, targetport), verify=False)
+        
+    if "global" in req.text: # each smb.conf will contain a [global] variable
         print("[\033[91m!\033[0m] This Citrix ADC Server: %s is still vulnerable to CVE-2019-19781." % (target))
     else:
         print("[\033[92m*\033[0m] Awesome! The server %s is not vulnerable." % (target))


### PR DESCRIPTION
`https` will not work on port 80: `ssl.SSLError: [SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:1076)`

`req.content` should be `req._content` or `req.text`: 
```
if ("global") in req.content: # each smb.conf will contain a [global] variable
TypeError: a bytes-like object is required, not 'str'
```